### PR TITLE
fix: status bar visibility and background running when starting winbar using winbarc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "powershell_script"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef8336090917f3d3a044256bc0e5c51d5420e5d09dfa1df4868083c5231a454"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +917,7 @@ name = "winbarc"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "powershell_script",
  "tokio",
  "winbar",
 ]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ That's the gist of it! There are more commands and options available that you ca
 free to use the `--help` option on any command (`winbar`, `winbarc`) or subcommand to see everything
 available to you.
 
+## Compiling from source
+
+Clone this repo and change into the project's directory. You can then compile using the following
+command:
+
+```
+cargo build [--release]
+```
+
+If you want to install `winbar` and `winbarc`, run the following commands with the respective
+project:
+
+```
+cargo install --path <./winbar | ./winbarc>
+```
+
+### A note on developing
+
+For an unknown reason, `winbarc` does not properly start `winbar` if `winbarc` is run using `cargo
+run`. If you wish to use `winbarc` to start `winbar`, make sure to install it using `cargo install`.
+
 ## Roadmap
 
 - More configuration options for existing components

--- a/winbar/src/container.rs
+++ b/winbar/src/container.rs
@@ -14,7 +14,7 @@ use windows::{
         UI::WindowsAndMessaging::{
             CreateWindowExW, DefWindowProcW, DispatchMessageW, PeekMessageW, PostQuitMessage,
             RegisterClassW, SetLayeredWindowAttributes, ShowWindow, TranslateMessage, LWA_COLORKEY,
-            MSG, PM_REMOVE, SW_SHOWDEFAULT, WM_CLOSE, WM_DESTROY, WM_PAINT, WNDCLASSW,
+            MSG, PM_REMOVE, SW_SHOWNORMAL, WM_CLOSE, WM_DESTROY, WM_PAINT, WNDCLASSW,
             WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_POPUP, WS_VISIBLE,
         },
     },
@@ -59,7 +59,7 @@ pub fn create_window() -> HWND {
 
         SetLayeredWindowAttributes(hwnd, COLORREF(TRANSPARENT_COLOR), 25, LWA_COLORKEY).ok();
 
-        let _success = ShowWindow(hwnd, SW_SHOWDEFAULT);
+        let _success = ShowWindow(hwnd, SW_SHOWNORMAL);
 
         hwnd
     }
@@ -72,12 +72,18 @@ pub fn listen(hwnd: HWND, recv: Receiver<WinbarAction>) {
     loop {
         if let Ok(action) = recv.try_recv() {
             match action {
+                WinbarAction::Shutdown => {
+                    WindowsApi::send_window_shutdown_msg(hwnd);
+                }
                 WinbarAction::UpdateWindow => unsafe {
                     // UpdateWindow(hwnd);
                     InvalidateRect(hwnd, None, true);
                 },
-                WinbarAction::Shutdown => {
-                    WindowsApi::send_window_shutdown_msg(hwnd);
+                WinbarAction::ShowWindow => {
+                    WindowsApi::show_window(hwnd);
+                }
+                WinbarAction::HideWindow => {
+                    WindowsApi::hide_window(hwnd);
                 }
             }
         }

--- a/winbar/src/lib.rs
+++ b/winbar/src/lib.rs
@@ -15,8 +15,10 @@ pub const DEFAULT_PORT: i32 = 10989;
 pub const DEFAULT_HOSTNAME: &str = "localhost";
 
 pub enum WinbarAction {
-    UpdateWindow,
     Shutdown,
+    UpdateWindow,
+    ShowWindow,
+    HideWindow,
 }
 
 #[derive(Getters, Clone)]

--- a/winbar/src/protocol.rs
+++ b/winbar/src/protocol.rs
@@ -18,8 +18,10 @@ use serde::{Deserialize, Serialize};
 /// A message sent to the server by the client.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ServerMessage {
-    UpdateWindow,
     Shutdown,
+    UpdateWindow,
+    ShowWindow,
+    HideWindow,
 }
 
 /// A server-bound payload.

--- a/winbar/src/server.rs
+++ b/winbar/src/server.rs
@@ -6,7 +6,7 @@ use tokio::{
     task::JoinHandle,
 };
 use winbar::{
-    protocol::{WinbarClientPayload, WinbarServerPayload},
+    protocol::{ServerMessage, WinbarClientPayload, WinbarServerPayload},
     WinbarAction, WinbarContext,
 };
 
@@ -93,11 +93,17 @@ impl WinbarServer {
         _stream: &TcpStream,
     ) -> Result<()> {
         match payload.message {
-            winbar::protocol::ServerMessage::UpdateWindow => {
+            ServerMessage::Shutdown => {
+                ctx.sender().send(WinbarAction::Shutdown)?;
+            }
+            ServerMessage::UpdateWindow => {
                 ctx.sender().send(WinbarAction::UpdateWindow)?;
             }
-            winbar::protocol::ServerMessage::Shutdown => {
-                ctx.sender().send(WinbarAction::Shutdown)?;
+            ServerMessage::ShowWindow => {
+                ctx.sender().send(WinbarAction::ShowWindow)?;
+            }
+            ServerMessage::HideWindow => {
+                ctx.sender().send(WinbarAction::HideWindow)?;
             }
         }
 

--- a/winbar/src/windows_api.rs
+++ b/winbar/src/windows_api.rs
@@ -14,7 +14,7 @@ use windows::{
             },
             GdiPlus::{GdiplusShutdown, GdiplusStartup, GdiplusStartupInput, Status},
         },
-        UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE},
+        UI::WindowsAndMessaging::{PostMessageW, ShowWindow, SW_HIDE, SW_SHOW, WM_CLOSE},
     },
 };
 
@@ -71,6 +71,18 @@ impl WindowsApi {
             SelectObject(hdc, font);
 
             SetTextColor(hdc, COLORREF(default_fg_color));
+        }
+    }
+
+    pub fn show_window(hwnd: HWND) {
+        unsafe {
+            let _ = ShowWindow(hwnd, SW_SHOW);
+        }
+    }
+
+    pub fn hide_window(hwnd: HWND) {
+        unsafe {
+            let _ = ShowWindow(hwnd, SW_HIDE);
         }
     }
 

--- a/winbarc/Cargo.toml
+++ b/winbarc/Cargo.toml
@@ -11,3 +11,4 @@ edition = { workspace = true }
 winbar = { path = "../winbar" }
 clap = { version = "4.5.4", features = ["cargo", "derive"] }
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "sync", "macros"] }
+powershell_script = { version = "1.1.0", features = ["core"] }

--- a/winbarc/src/cli.rs
+++ b/winbarc/src/cli.rs
@@ -31,4 +31,8 @@ pub enum WinbarSubcommand {
     Stop,
     /// Sends a message to update the status bar window
     UpdateWindow,
+    /// Sends a message to show the status bar
+    Show,
+    /// Sends a message to hide the status bar
+    Hide,
 }


### PR DESCRIPTION
This PR fixes a couple issues:
- `winbar` would not continue running after it is started using `winbarc` and the terminal is then closed
  - We now use `Start-Process` to run `winbar` in the background
 - The status bar window would be hidden by default in specific cases (e.g., when run using `Start-Process` with `-WindowStyle hidden`)
   - The window now uses `SW_SHOWNORMAL` instead of `SW_SHOWDEFAULT` so that it is properly shown in those cases

This PR also adds in 2 new CLI commands to manage the status bar:
- `winbarc show` to show the status bar
- `winbarc hide` to hide the status bar